### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Install the node.js dependencies (`elm` platform):
 ```sh
 npm install
 ```
-> **Note**: We install `elm` (_the `elm' compiler_)
+> **Note**: We install `elm` (_the `elm` compiler_)
 _locally_ for the "_quick-start_".
 If you decide to use it for your own project(s),
 you _can_ install it _globally_ using


### PR DESCRIPTION
hello,

there was an unfinished code block that messed up the quote and it didn't show `npm install -g elm` correctly