### PR TITLE
The state of the checkboxes does not match the model state

### DIFF
--- a/examples/checkboxes.elm
+++ b/examples/checkboxes.elm
@@ -23,7 +23,7 @@ type alias Model =
 
 init : Model
 init =
-    Model True True True
+    Model False False False
 
 
 

--- a/examples/checkboxes.elm
+++ b/examples/checkboxes.elm
@@ -62,7 +62,7 @@ view model =
         ]
 
 
-checkbox : msg -> String -> Html msg
+checkbox : Msg -> String -> Html Msg
 checkbox msg name =
     label
         [ style "padding" "20px" ]


### PR DESCRIPTION
There is an issue in the current version of the "checkboxes.elm" example.
If the "Email Notifications", "Video Autoplay" and "Use Location" checkboxes are unchecked, then the state of the Model is
{
  autoplay = True
  location = True
  notifications = True
}

But the expected result (if checkboxes are unchecked) is:

{
  autoplay = False
  location = False
  notifications = False
}

And vice versa when checkboxes are checked, the state of the Model should be 

{
  autoplay = True
  location = True
  notifications = True
}

The pull request was created to fix this issue.